### PR TITLE
Implement sample datasets

### DIFF
--- a/datasets/athletes.js
+++ b/datasets/athletes.js
@@ -1,0 +1,27 @@
+export const athletes = {
+  id: { type: "UUID", primary: true },
+  club_id: { type: "Ref", ref: "clubs", required: true },
+  team_id: { type: "Ref", ref: "teams", required: true },
+  first_name: { type: "Text", required: true },
+  last_name: { type: "Text", required: true },
+  birth_date: { type: "Date", required: true },
+  position: {
+    type: "Enum",
+    values: ["GK", "CB", "LB", "RB", "CM", "CF", "ST", "LW", "RW"],
+    required: true,
+  },
+  status: {
+    type: "Enum",
+    values: ["active", "injured", "suspended"],
+    default: "active",
+  },
+  is_registered: { type: "Boolean", default: true },
+  created_at: { type: "DateTime", default: "now" },
+  updated_at: { type: "DateTime", default: "now" },
+};
+
+export const athletes_indexes = [
+  { fields: ["club_id"] },
+  { fields: ["team_id"] },
+  { fields: ["status"] },
+];

--- a/datasets/documents.js
+++ b/datasets/documents.js
@@ -1,0 +1,30 @@
+export const documents = {
+  id: { type: "UUID", primary: true },
+  athlete_id: { type: "Ref", ref: "athletes", required: true },
+  club_id: { type: "Ref", ref: "clubs", required: true },
+  type: {
+    type: "Enum",
+    values: [
+      "cartellino",
+      "visita_medica",
+      "nulla_osta",
+      "certificato_medico",
+      "assicurazione",
+    ],
+    required: true,
+  },
+  file_url: { type: "Text", required: true },
+  file_name: { type: "Text", required: true },
+  file_size: { type: "Number", required: true },
+  expires_at: { type: "Date", nullable: true },
+  uploaded_by: { type: "Ref", ref: "users", required: true },
+  created_at: { type: "DateTime", default: "now" },
+  updated_at: { type: "DateTime", default: "now" },
+};
+
+export const documents_indexes = [
+  { fields: ["athlete_id"] },
+  { fields: ["club_id"] },
+  { fields: ["type"] },
+  { fields: ["expires_at"] },
+];

--- a/datasets/matches.js
+++ b/datasets/matches.js
@@ -1,0 +1,22 @@
+export const matches = {
+  id: { type: "UUID", primary: true },
+  home_team_id: { type: "Ref", ref: "teams", required: true },
+  away_team_id: { type: "Ref", ref: "teams", required: true },
+  matchday: { type: "Number", required: true },
+  competition: { type: "Text", required: true },
+  date: { type: "DateTime", required: true },
+  status: {
+    type: "Enum",
+    values: ["scheduled", "played", "cancelled"],
+    default: "scheduled",
+  },
+  created_at: { type: "DateTime", default: "now" },
+  updated_at: { type: "DateTime", default: "now" },
+};
+
+export const matches_indexes = [
+  { fields: ["home_team_id"] },
+  { fields: ["away_team_id"] },
+  { fields: ["date"] },
+  { fields: ["status"] },
+];

--- a/datasets/seeds/athletes.seed.json
+++ b/datasets/seeds/athletes.seed.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "ath-1",
+    "club_id": "club-1",
+    "team_id": "team-1",
+    "first_name": "Marco",
+    "last_name": "Rossi",
+    "birth_date": "1995-03-15",
+    "position": "CM",
+    "status": "active",
+    "is_registered": true,
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "ath-2",
+    "club_id": "club-1",
+    "team_id": "team-1",
+    "first_name": "Luca",
+    "last_name": "Bianchi",
+    "birth_date": "2000-07-10",
+    "position": "ST",
+    "status": "injured",
+    "is_registered": true,
+    "created_at": "2024-01-02T00:00:00.000Z",
+    "updated_at": "2024-01-02T00:00:00.000Z"
+  }
+]

--- a/datasets/seeds/documents.seed.json
+++ b/datasets/seeds/documents.seed.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "doc-1",
+    "athlete_id": "ath-1",
+    "club_id": "club-1",
+    "type": "cartellino",
+    "file_url": "https://example.com/doc1.pdf",
+    "file_name": "cartellino_rossi.pdf",
+    "file_size": 123456,
+    "expires_at": "2024-12-31",
+    "uploaded_by": "user-1",
+    "created_at": "2024-01-15T00:00:00.000Z",
+    "updated_at": "2024-01-15T00:00:00.000Z"
+  },
+  {
+    "id": "doc-2",
+    "athlete_id": "ath-1",
+    "club_id": "club-1",
+    "type": "visita_medica",
+    "file_url": "https://example.com/doc2.pdf",
+    "file_name": "visita_medica_2024.pdf",
+    "file_size": 234567,
+    "expires_at": "2024-01-30",
+    "uploaded_by": "user-1",
+    "created_at": "2023-06-15T00:00:00.000Z",
+    "updated_at": "2023-06-15T00:00:00.000Z"
+  }
+]

--- a/datasets/seeds/matches.seed.json
+++ b/datasets/seeds/matches.seed.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "match-1",
+    "home_team_id": "team-1",
+    "away_team_id": "team-2",
+    "matchday": 1,
+    "competition": "Serie A",
+    "date": "2024-03-01T15:00:00.000Z",
+    "status": "scheduled",
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "match-2",
+    "home_team_id": "team-3",
+    "away_team_id": "team-4",
+    "matchday": 1,
+    "competition": "Serie A",
+    "date": "2024-03-02T18:00:00.000Z",
+    "status": "scheduled",
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  }
+]

--- a/datasets/seeds/users.seed.json
+++ b/datasets/seeds/users.seed.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "user-1",
+    "email": "dirigente@example.com",
+    "first_name": "Luigi",
+    "last_name": "Bianchi",
+    "role": "DIRIGENTE",
+    "club_id": "club-1",
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "user-2",
+    "email": "allenatore@example.com",
+    "first_name": "Mauro",
+    "last_name": "Verdi",
+    "role": "ALLENATORE",
+    "club_id": "club-1",
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  }
+]

--- a/datasets/users.js
+++ b/datasets/users.js
@@ -1,0 +1,20 @@
+export const users = {
+  id: { type: "UUID", primary: true },
+  club_id: { type: "Ref", ref: "clubs", required: true },
+  email: { type: "Email", unique: true, required: true },
+  first_name: { type: "Text", required: true },
+  last_name: { type: "Text", required: true },
+  role: {
+    type: "Enum",
+    values: ["ALLENATORE", "DIRIGENTE", "DS", "PRESIDENTE", "SYSTEM"],
+    default: "DIRIGENTE",
+  },
+  created_at: { type: "DateTime", default: "now" },
+  updated_at: { type: "DateTime", default: "now" },
+};
+
+export const users_indexes = [
+  { fields: ["email"], unique: true },
+  { fields: ["club_id"] },
+  { fields: ["role"] },
+];

--- a/roadmap.md
+++ b/roadmap.md
@@ -8,7 +8,7 @@ Questa roadmap ti aiuta a tenere traccia delle attività necessarie per una demo
 - [x] Avviare il workspace con `pnpm dev` (portali `play`, `club`, `agents`).
 
 ## 2. Dati di Esempio
-- [ ] Popolare i dataset con atleti, utenti, partite e documenti di test.
+- [x] Popolare i dataset con atleti, utenti, partite e documenti di test.
 
 ## 3. Collegamento Backend e Frontend
 - [ ] Verificare che le pagine React richiedano i dati dai Flow e salvino sui dataset.


### PR DESCRIPTION
## Summary
- add dataset definitions for athletes, users, matches and documents
- provide seed data for demo usage
- mark roadmap item as completed

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm e2e` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bcf9e3008322a89344177cd9981a