### PR TITLE
Implement roadmap step 3

### DIFF
--- a/apps/club/src/pages/AthleteDetail.tsx
+++ b/apps/club/src/pages/AthleteDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { runFlow } from '../utils/runFlow';
 import Tabs, { useTabState } from '@ui/components/Tabs';
 import DocumentList from '@ui/components/DocumentList';
 import UploadDropzone from '@ui/components/UploadDropzone';
@@ -103,103 +104,11 @@ export default function AthleteDetail() {
     
     setLoading(true);
     try {
-      // TODO: Replace with actual API calls
-      // Simulate API calls
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
-      // Mock athlete data
-      setAthlete({
-        id,
-        first_name: 'Marco',
-        last_name: 'Rossi',
-        birth_date: '1995-03-15',
-        position: 'Centrocampista',
-        team_id: 'team-1',
-        club_id: 'club-1',
-        attributes: {
-          pace: 78,
-          shooting: 82,
-          passing: 85,
-          defending: 65,
-          physical: 80
-        },
-        status: 'active',
-        contract_end: '2025-06-30',
-        market_value: 150000
-      });
-
-      // Mock documents with expired ones
-      setDocuments([
-        {
-          id: 'doc-1',
-          type: 'cartellino',
-          file_name: 'cartellino_rossi.pdf',
-          file_url: 'https://example.com/doc1.pdf',
-          expires_at: '2024-12-31',
-          created_at: '2024-01-15',
-          uploaded_by: 'admin'
-        },
-        {
-          id: 'doc-2',
-          type: 'visita_medica',
-          file_name: 'visita_medica_2024.pdf',
-          file_url: 'https://example.com/doc2.pdf',
-          expires_at: '2024-01-30', // Expired
-          created_at: '2023-06-15',
-          uploaded_by: 'admin'
-        },
-        {
-          id: 'doc-3',
-          type: 'certificato_medico',
-          file_name: 'certificato_medico.pdf',
-          file_url: 'https://example.com/doc3.pdf',
-          expires_at: '2024-02-15', // Expired
-          created_at: '2023-08-10',
-          uploaded_by: 'admin'
-        }
-      ]);
-
-      // Mock notes
-      setNotes([
-        {
-          id: 'note-1',
-          note_text: 'Ottima prestazione in allenamento. Migliorato il tiro da fuori area. Continua a lavorare sulla precisione nei passaggi lunghi.',
-          created_at: '2024-01-10',
-          coach_id: 'coach-1',
-          coach_name: 'Mister Bianchi',
-          visibility: 'team',
-          tags: ['tattica', 'fisica'],
-          priority: 'high'
-        },
-        {
-          id: 'note-2',
-          note_text: 'Buona condizione fisica generale. Necessario migliorare la resistenza per i 90 minuti.',
-          created_at: '2024-01-05',
-          coach_id: 'coach-1',
-          coach_name: 'Preparatore Verdi',
-          visibility: 'staff',
-          tags: ['fisica'],
-          priority: 'medium'
-        }
-      ]);
-
-      // Mock events
-      setEvents([
-        {
-          id: 'event-1',
-          type_enum: 'visita_medica',
-          due_at: '2024-06-15',
-          description: 'Visita medica di controllo annuale',
-          status: 'pending'
-        },
-        {
-          id: 'event-2',
-          type_enum: 'compleanno',
-          due_at: '2024-03-15',
-          description: 'Compleanno di Marco Rossi',
-          status: 'pending'
-        }
-      ]);
+      const data = await runFlow("Athlete_GetDetail", { athlete_id: id });
+      setAthlete(data.athlete);
+      setDocuments(data.documents || []);
+      setNotes(data.notes || []);
+      setEvents(data.events || []);
 
     } catch (err) {
       setError('Errore nel caricamento dei dati atleta');
@@ -211,18 +120,17 @@ export default function AthleteDetail() {
 
   const handleDocumentUpload = async (file: File) => {
     try {
-      // TODO: Call Document_Upload flow
-      console.log('Uploading document:', file.name);
-      
-      // Simulate upload
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Refresh documents list
+      await runFlow('Document_Upload', {
+        athlete_id: id,
+        file,
+        type: 'certificato_medico'
+      });
+
       await loadAthleteData();
-      
+
     } catch (error) {
       console.error('Upload error:', error);
-      throw new Error('Errore durante l\'upload del documento');
+      throw new Error("Errore durante l'upload del documento");
     }
   };
 
@@ -231,17 +139,13 @@ export default function AthleteDetail() {
     
     setIsAddingNote(true);
     try {
-      // TODO: Call Athlete_AddNote flow
-      console.log('Adding note:', {
+      await runFlow('Athlete_AddNote', {
         athlete_id: id,
         note_text: newNote,
         visibility: noteVisibility,
         tags: noteTags,
         priority: notePriority
       });
-      
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 500));
       
       // Reset form
       setNewNote('');

--- a/apps/club/src/pages/AthletesList.tsx
+++ b/apps/club/src/pages/AthletesList.tsx
@@ -1,12 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { runFlow } from '../utils/runFlow';
 
-export default function AthletesList() {
-  return <main className="p-4 space-y-6 max-w-6xl mx-auto">
-    <h1 className="text-2xl font-bold">Lista Atleti</h1>
-    <div className="component border p-4 rounded-lg">AthletesList TODO</div>
-  </main>;
+interface Athlete {
+  id: string;
+  first_name: string;
+  last_name: string;
+  position: string;
 }
 
-// TODO: implementare
-// Features: tabella atleti con AthleteCard, filtri, ricerca, paginazione
-// Integration: fetch atleti, routing a AthleteDetail
+export default function AthletesList() {
+  const [athletes, setAthletes] = useState<Athlete[]>([]);
+  useEffect(() => {
+    runFlow('Athletes_List', {}).then(data => setAthletes(data.athletes || []));
+  }, []);
+
+  return (
+    <main className="p-4 space-y-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold">Lista Atleti</h1>
+      <ul className="space-y-2">
+        {athletes.map(a => (
+          <li key={a.id} className="border p-2 rounded">
+            {a.first_name} {a.last_name} - {a.position}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/club/src/utils/runFlow.ts
+++ b/apps/club/src/utils/runFlow.ts
@@ -1,0 +1,13 @@
+export async function runFlow(flowName: string, payload: any) {
+  const res = await fetch(`/services/flows/${flowName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(txt);
+  }
+  const json = await res.json();
+  return json.data;
+}

--- a/flows/Athlete_GetDetail.js
+++ b/flows/Athlete_GetDetail.js
@@ -1,0 +1,15 @@
+import { athletes, documents, athlete_notes } from 'bolt:data';
+
+export default async function Athlete_GetDetail(input, _context) {
+  const athlete_id = input.athlete_id;
+  if (!athlete_id) throw new Error('athlete_id required');
+  const athlete = await athletes.get(athlete_id);
+  const docs = await documents.find({ athlete_id });
+  const notes = await athlete_notes.find({ athlete_id, is_archived: false });
+  return {
+    athlete,
+    documents: docs,
+    notes,
+    events: []
+  };
+}

--- a/flows/Athletes_List.js
+++ b/flows/Athletes_List.js
@@ -1,0 +1,6 @@
+import { athletes } from 'bolt:data';
+
+export default async function Athletes_List() {
+  const list = await athletes.find({});
+  return { athletes: list };
+}

--- a/packages/common/src/bolt-data-stub.ts
+++ b/packages/common/src/bolt-data-stub.ts
@@ -1,103 +1,96 @@
-// Stub locale per "bolt:data" (solo ambiente dev)
-export const matches = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
-export const tactics = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const seedsDir = join(__dirname, '../../datasets/seeds');
 
-export const players = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+function loadSeed(file: string) {
+  try {
+    return JSON.parse(readFileSync(join(seedsDir, file), 'utf-8'));
+  } catch {
+    return [];
+  }
+}
 
-export const teams = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+function generateId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
 
-export const lineups = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+function match(item: any, query: any) {
+  for (const key of Object.keys(query)) {
+    const cond = query[key];
+    const val = item[key];
+    if (cond && typeof cond === 'object') {
+      if (cond.$gte && val < cond.$gte) return false;
+      if (cond.$lte && val > cond.$lte) return false;
+      if (cond.$ne !== undefined && val === cond.$ne) return false;
+    } else if (val !== cond) {
+      return false;
+    }
+  }
+  return true;
+}
 
-export const lineup_players = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true,
-  bulkInsert: async (_data: any[]) => _data.map(() => 'mock-id')
-};
+function createDataset(store: any[], prefix: string, bulk = false) {
+  return {
+    get: async (id: string) => store.find(i => i.id === id) || null,
+    find: async (query: any = {}) => store.filter(i => match(i, query)),
+    insert: async (data: any) => {
+      const id = data.id || generateId(prefix);
+      store.push({ ...data, id });
+      return id;
+    },
+    update: async (id: string, data: any) => {
+      const idx = store.findIndex(i => i.id === id);
+      if (idx === -1) return false;
+      store[idx] = { ...store[idx], ...data };
+      return true;
+    },
+    delete: async (id: string) => {
+      const idx = store.findIndex(i => i.id === id);
+      if (idx === -1) return false;
+      store.splice(idx, 1);
+      return true;
+    },
+    ...(bulk && {
+      bulkInsert: async (items: any[]) =>
+        items.map(item => {
+          const id = item.id || generateId(prefix);
+          store.push({ ...item, id });
+          return id;
+        })
+    })
+  } as any;
+}
 
-export const athletes = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+const matchesStore = loadSeed('matches.seed.json');
+const athletesStore = loadSeed('athletes.seed.json');
+const documentsStore = loadSeed('documents.seed.json');
+const usersStore = loadSeed('users.seed.json');
 
-export const athlete_notes = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+const tacticsStore: any[] = [];
+const playersStore: any[] = [];
+const teamsStore: any[] = [];
+const lineupsStore: any[] = [];
+const lineupPlayersStore: any[] = [];
+const athleteNotesStore: any[] = [];
+const logNotificationsStore: any[] = [];
+const eventsCalendarStore: any[] = [];
 
-export const documents = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
+export const matches = createDataset(matchesStore, 'match');
+export const tactics = createDataset(tacticsStore, 'tactic');
+export const players = createDataset(playersStore, 'player');
+export const teams = createDataset(teamsStore, 'team');
+export const lineups = createDataset(lineupsStore, 'lineup');
+export const lineup_players = createDataset(lineupPlayersStore, 'lp', true);
+export const athletes = createDataset(athletesStore, 'athlete');
+export const athlete_notes = createDataset(athleteNotesStore, 'note');
+export const documents = createDataset(documentsStore, 'doc');
+export const log_notifications = createDataset(logNotificationsStore, 'log');
+export const events_calendar = createDataset(eventsCalendarStore, 'event');
+export const users = createDataset(usersStore, 'user');
 
-export const log_notifications = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  findOne: async (_query: any) => null,
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
-
-export const events_calendar = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
-
-export const users = {
-  get: async (_id: string) => null,
-  find: async (_query: any) => [],
-  insert: async (_data: any) => 'mock-id',
-  update: async (_id: string, _data: any) => true,
-  delete: async (_id: string) => true
-};
-
-// Export default per compatibilità
 export const data = {
   matches,
   tactics,

--- a/services/flows/index.js
+++ b/services/flows/index.js
@@ -1,0 +1,22 @@
+export default async function handleRequest(req) {
+  const url = new URL(req.url);
+  const parts = url.pathname.split('/');
+  const flowName = parts[parts.length - 1];
+
+  if (!flowName) {
+    return new Response(JSON.stringify({ success: false, error: 'FLOW_NOT_SPECIFIED' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ success: false, error: 'METHOD_NOT_ALLOWED' }), { status: 405, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  try {
+    const body = await req.json();
+    const module = await import(`../../flows/${flowName}.js`);
+    const result = await module.default(body, {});
+    return new Response(JSON.stringify({ success: true, data: result }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    return new Response(JSON.stringify({ success: false, error: err.message }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+}

--- a/services/flows/package.json
+++ b/services/flows/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sportiverse/flows-service",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node --watch index.js",
+    "build": "echo 'building flows service'",
+    "clean": "rm -rf node_modules"
+  },
+  "dependencies": {
+    "@sportiverse/common": "workspace:*"
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory dataset stub with seed data
- create simple flow runner service
- implement new flows `Athlete_GetDetail` and `Athletes_List`
- add `runFlow` helper for club app
- hook Athlete pages to backend flows

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb4ca1608322b87715ada7e0653c