### PR TITLE
Implement JWT auth and protect CRM flows

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -19,8 +19,8 @@ Questa roadmap ti aiuta a tenere traccia delle attività necessarie per una demo
 - [x] Testare la function `sendDailyAlerts.ts` e controllare `log_notifications`.
 
 ## 5. Autenticazione
-- [ ] Implementare la generazione di JWT e un endpoint di login di base.
-- [ ] Proteggere le rotte CRM con il middleware di autorizzazione.
+- [x] Implementare la generazione di JWT e un endpoint di login di base.
+- [x] Proteggere le rotte CRM con il middleware di autorizzazione.
 
 ## 6. Verifica Permessi
 - [ ] Applicare `checkPermission.ts` e la mappa ACL a tutti i Flow sensibili.

--- a/services/auth/checkPermission.ts
+++ b/services/auth/checkPermission.ts
@@ -1,0 +1,19 @@
+import { users } from 'bolt:data';
+import { ACL, hasPermission } from './acl';
+
+export async function checkPermission(userId: string, clubId: string, permission: keyof typeof ACL): Promise<void> {
+  const user = await users.get(userId);
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+  if (user.club_id !== clubId) {
+    throw new Error('FORBIDDEN');
+  }
+  const requiredRole = ACL[permission];
+  if (!requiredRole) {
+    throw new Error('PERMISSION_UNDEFINED');
+  }
+  if (!hasPermission(user.role, requiredRole)) {
+    throw new Error('INSUFFICIENT_ROLE');
+  }
+}

--- a/services/auth/index.js
+++ b/services/auth/index.js
@@ -1,14 +1,13 @@
-// TODO: Implementare servizio di autenticazione
-// - JWT RS256 con rotazione chiave
-// - Gestione sessioni
-// - OAuth providers
+import loginHandler from './login.ts';
 
-export default async function handler(req, res) {
-  return new Response(JSON.stringify({ 
-    service: 'auth',
-    status: 'TODO',
-    version: '1.0.0'
-  }), {
-    headers: { 'Content-Type': 'application/json' }
-  })
+export default async function handler(req) {
+  const url = new URL(req.url);
+  if (url.pathname.endsWith('/login')) {
+    return loginHandler(req);
+  }
+
+  return new Response(
+    JSON.stringify({ service: 'auth', status: 'OK', version: '1.0.0' }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
 }

--- a/services/auth/jwt.ts
+++ b/services/auth/jwt.ts
@@ -1,0 +1,36 @@
+import crypto from 'crypto';
+
+const DEFAULT_EXPIRATION = 60 * 60; // 1h in seconds
+const secret = process.env.JWT_SECRET || 'change-me';
+
+function base64url(input: Buffer | string) {
+  return Buffer.from(input).toString('base64url');
+}
+
+export function sign(payload: Record<string, any>, expiresIn: number = DEFAULT_EXPIRATION): string {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + expiresIn;
+  const tokenPayload = { ...payload, exp };
+  const encodedHeader = base64url(JSON.stringify(header));
+  const encodedPayload = base64url(JSON.stringify(tokenPayload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = crypto.createHmac('sha256', secret).update(data).digest('base64url');
+  return `${data}.${signature}`;
+}
+
+export function verify(token: string): Record<string, any> {
+  const [headerB64, payloadB64, signature] = token.split('.');
+  if (!headerB64 || !payloadB64 || !signature) {
+    throw new Error('INVALID_TOKEN');
+  }
+  const data = `${headerB64}.${payloadB64}`;
+  const expectedSig = crypto.createHmac('sha256', secret).update(data).digest('base64url');
+  if (expectedSig !== signature) {
+    throw new Error('INVALID_SIGNATURE');
+  }
+  const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'));
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    throw new Error('TOKEN_EXPIRED');
+  }
+  return payload;
+}

--- a/services/auth/login.ts
+++ b/services/auth/login.ts
@@ -1,0 +1,41 @@
+import { users } from 'bolt:data';
+import { sign } from './jwt';
+
+export default async function loginHandler(req: Request): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ success: false, error: 'METHOD_NOT_ALLOWED' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  try {
+    const { email } = await req.json();
+    if (!email) {
+      return new Response(JSON.stringify({ success: false, error: 'EMAIL_REQUIRED' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const user = await users.findOne({ email });
+    if (!user) {
+      return new Response(JSON.stringify({ success: false, error: 'INVALID_CREDENTIALS' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const token = sign({ id: user.id, email: user.email, role: user.role, club_id: user.club_id });
+
+    return new Response(
+      JSON.stringify({ success: true, token, user: { id: user.id, email: user.email, role: user.role, club_id: user.club_id } }),
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    return new Response(JSON.stringify({ success: false, error: (err as Error).message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}

--- a/services/flows/index.js
+++ b/services/flows/index.js
@@ -1,22 +1,54 @@
+import { verify } from '../auth/jwt.ts';
+
 export default async function handleRequest(req) {
   const url = new URL(req.url);
   const parts = url.pathname.split('/');
   const flowName = parts[parts.length - 1];
 
   if (!flowName) {
-    return new Response(JSON.stringify({ success: false, error: 'FLOW_NOT_SPECIFIED' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify({ success: false, error: 'FLOW_NOT_SPECIFIED' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ success: false, error: 'METHOD_NOT_ALLOWED' }), { status: 405, headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify({ success: false, error: 'METHOD_NOT_ALLOWED' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const auth = req.headers.get('authorization');
+  if (!auth) {
+    return new Response(JSON.stringify({ success: false, error: 'UNAUTHORIZED' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  let payload;
+  try {
+    payload = verify(auth.replace('Bearer ', ''));
+  } catch (err) {
+    return new Response(JSON.stringify({ success: false, error: 'INVALID_TOKEN' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   try {
     const body = await req.json();
     const module = await import(`../../flows/${flowName}.js`);
-    const result = await module.default(body, {});
-    return new Response(JSON.stringify({ success: true, data: result }), { headers: { 'Content-Type': 'application/json' } });
+    const context = { user: { id: payload.id, role: payload.role }, club: { id: payload.club_id }, token: auth.replace('Bearer ', '') };
+    const result = await module.default(body, context);
+    return new Response(JSON.stringify({ success: true, data: result }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
   } catch (err) {
-    return new Response(JSON.stringify({ success: false, error: err.message }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify({ success: false, error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- implement `jwt.ts` helper for issuing and verifying tokens
- create a login endpoint and update auth service routing
- add authorization middleware to CRM flow handler
- add permission check utility
- mark authentication step as completed in roadmap

## Testing
- `pnpm install`
- `pnpm test` *(fails: expected +0 to be 1)*
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6862d26999388322b34679fa5d3aa2b5